### PR TITLE
Removal of space in argument which failed spark-submit & set master to local

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ How to run spark program through Intellij?
 - Set main class as 
     org.apache.spark.deploy.SparkSubmit
 - Set program arguments as
-   --master local -- class <main_class> target/scala-2.12/<jar_name>
+   --master local --class <main_class> target/scala-2.12/<jar_name>

--- a/src/main/scala/thoughtworks/NewYorkTimes.scala
+++ b/src/main/scala/thoughtworks/NewYorkTimes.scala
@@ -6,7 +6,11 @@ import thoughtworks.Analyzer._
 
 object NewYorkTimes {
   def main(args: Array[String]): Unit = {
-    val spark = SparkSession.builder().appName("Analyze New York Times - Books Data Spark App").getOrCreate()
+    val spark = SparkSession
+      .builder()
+      .master("local")
+      .appName("Analyze New York Times - Books Data Spark App")
+      .getOrCreate()
 
     val nytDF = spark.read
       .option("inferSchema", "true")


### PR DESCRIPTION
Removal of extra space in argument for spark-submit and set master to local